### PR TITLE
A couple of bug fixes found while integrating this logic into my solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ $RECYCLE.BIN/
 *.msi
 *.msm
 *.msp
+/.vs

--- a/OpenIdAuthentication.cs
+++ b/OpenIdAuthentication.cs
@@ -200,7 +200,7 @@ namespace OpenId.AspNet.Authentication
             }
             catch(Exception e)
             {
-                RedirectToError(httpContext, 5000, e.Message);
+                RedirectToError(httpContext, 5000, e.Message.Replace("\n", " " ));
                 return;
             }
 

--- a/OpenIdAuthentication.cs
+++ b/OpenIdAuthentication.cs
@@ -46,7 +46,7 @@ namespace OpenId.AspNet.Authentication
             Options.TrustedAuthoritiesSet.Add(Options.Authority.ToLowerInvariant().RemoveTrailingSlash());
 
             //convert endpoint prefixes into app relative virtual path
-            if(options.DemandAuthorizationHeaderForEndpointPrefixes != null)
+            if(options.DemandAuthorizationHeaderForEndpointPrefixes?.Count > 0)
             {
                 var list = new List<string>();
                 foreach(var p in options.DemandAuthorizationHeaderForEndpointPrefixes)
@@ -259,7 +259,7 @@ namespace OpenId.AspNet.Authentication
                 return;
             }
             //ignore cookie if request goes to listed Ajax/WebApi endpoints
-            if(Options.DemandAuthorizationHeaderForEndpointPrefixes != null)
+            if(Options.DemandAuthorizationHeaderForEndpointPrefixes?.Count > 0)
             {
                 if(Options.DemandAuthorizationHeaderForEndpointPrefixes.Any(p => request.AppRelativeCurrentExecutionFilePath != null && request.AppRelativeCurrentExecutionFilePath.StartsWith(p)))
                 {


### PR DESCRIPTION
Bug found during while code was attempting to handle exception.  Problem is that the message had line breaks and this is not allowed.  Added logic replace line breaks with spaces.

Also noticed that options.DemandAuthorizationHeaderForEndpointPrefixes is initialized during the construction of the OpenIdConnectOptions class as such this is never null.  I updated the logic to check if the collection is empty.

Excellent work! And thank you for this.